### PR TITLE
Add license injector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+# Copyright (C) 2019 The Trustees of Indiana University
+# SPDX-License-Identifier: BSD-3-Clause
 frontend/node_modules
 php/vendor
 php/composer.lock

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,2 @@
-/*
 Copyright (C) 2019 The Trustees of Indiana University
 SPDX-License-Identifier: BSD-3-Clause
-*/
-angular.module('apiHost', []);

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,23 @@
+# Collectome frontend
+
+## Install development dependencies
+
+```bash
+npm install
+```
+
+## Run development server
+
+```bash
+npm run serve
+```
+
+## Licensing
+
+You can automatically inject copyright and license info into the source files using the `license` script. Just edit the _LICENSE_ file to have the proper year, then run:
+
+```bash
+npm run license
+```
+
+Note: this script will inject license information into files in all directories under _collectome_, not just _frontend_.

--- a/frontend/api-host/api-host.value.js
+++ b/frontend/api-host/api-host.value.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('apiHost')
   .value('apiHost', 'http://localhost:8081'); // dev

--- a/frontend/api-host/api-host.value.spec.js
+++ b/frontend/api-host/api-host.value.spec.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 describe('apiHost', () => {
   let apiHost;
 

--- a/frontend/api/api.module.js
+++ b/frontend/api/api.module.js
@@ -1,1 +1,5 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('api', ['apiHost']);

--- a/frontend/api/api.service.js
+++ b/frontend/api/api.service.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('api')
   .service('Api', function (apiHost, $q, $http) {

--- a/frontend/app.config.js
+++ b/frontend/app.config.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('collectomeApp')
   .config(['$locationProvider', '$routeProvider',

--- a/frontend/app.module.js
+++ b/frontend/app.module.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('collectomeApp', [
   'ngRoute',
   'sameoriginCheck',

--- a/frontend/assets/common.css
+++ b/frontend/assets/common.css
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
   #avl-shim {
     margin-bottom: 1rem;
   }

--- a/frontend/authentication/authentication.module.js
+++ b/frontend/authentication/authentication.module.js
@@ -1,2 +1,6 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('authentication', []);
 

--- a/frontend/authentication/authentication.service.js
+++ b/frontend/authentication/authentication.service.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('authentication')
   .service('Authentication', function () {

--- a/frontend/dev-server.js
+++ b/frontend/dev-server.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 /**
  * Start browser-sync server with URL rewriting to enable HTML5 mode
  * See https://docs.angularjs.org/guide/$location#hashbang-and-html5-modes

--- a/frontend/exhibit-config-display/exhibit-config-display.component.js
+++ b/frontend/exhibit-config-display/exhibit-config-display.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('exhibitConfigDisplay')
   .component('exhibitConfigDisplay', {

--- a/frontend/exhibit-config-display/exhibit-config-display.module.js
+++ b/frontend/exhibit-config-display/exhibit-config-display.module.js
@@ -1,1 +1,5 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitConfigDisplay', ['angular-jsoneditor']);

--- a/frontend/exhibit-config-display/exhibit-config-display.template.html
+++ b/frontend/exhibit-config-display/exhibit-config-display.template.html
@@ -1,1 +1,5 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <angular-jsoneditor ng-model="$ctrl.model" options="$ctrl.options"></angular-jsoneditor>

--- a/frontend/exhibit-config-editor/exhibit-config-editor.component.js
+++ b/frontend/exhibit-config-editor/exhibit-config-editor.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('exhibitConfigEditor')
   .component('exhibitConfigEditor', {

--- a/frontend/exhibit-config-editor/exhibit-config-editor.module.js
+++ b/frontend/exhibit-config-editor/exhibit-config-editor.module.js
@@ -1,1 +1,5 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitConfigEditor', ['angular-jsoneditor']);

--- a/frontend/exhibit-config-editor/exhibit-config-editor.template.html
+++ b/frontend/exhibit-config-editor/exhibit-config-editor.template.html
@@ -1,1 +1,5 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <angular-jsoneditor ng-model="$ctrl.model" options="$ctrl.options"></angular-jsoneditor>

--- a/frontend/exhibit-config-factory/exhibit-config-factory.factory.js
+++ b/frontend/exhibit-config-factory/exhibit-config-factory.factory.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('exhibitConfigFactory')
   .factory('exhibitConfigFactory', () => {

--- a/frontend/exhibit-config-factory/exhibit-config-factory.module.js
+++ b/frontend/exhibit-config-factory/exhibit-config-factory.module.js
@@ -1,1 +1,5 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitConfigFactory', []);

--- a/frontend/exhibit-config-preview/exhibit-config-preview.component.js
+++ b/frontend/exhibit-config-preview/exhibit-config-preview.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 /* eslint-disable object-shorthand */
 /* eslint-disable func-names */
 /* eslint-disable indent */

--- a/frontend/exhibit-config-preview/exhibit-config-preview.module.js
+++ b/frontend/exhibit-config-preview/exhibit-config-preview.module.js
@@ -1,1 +1,5 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitConfigPreview', ['gridster', 'utilities']);

--- a/frontend/exhibit-config-preview/exhibit-config-preview.template.html
+++ b/frontend/exhibit-config-preview/exhibit-config-preview.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <style>
   #gridster {
     margin: 50px;

--- a/frontend/exhibit-create/exhibit-create.component.js
+++ b/frontend/exhibit-create/exhibit-create.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('exhibitCreate')
   .component('exhibitCreate', {

--- a/frontend/exhibit-create/exhibit-create.module.js
+++ b/frontend/exhibit-create/exhibit-create.module.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitCreate', [
   'authentication',
   'utilities',

--- a/frontend/exhibit-create/exhibit-create.template.html
+++ b/frontend/exhibit-create/exhibit-create.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <main role="main" class="no-section-nav">
 
 

--- a/frontend/exhibit-detail/exhibit-detail.component.js
+++ b/frontend/exhibit-detail/exhibit-detail.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('exhibitDetail')
   .component('exhibitDetail', {

--- a/frontend/exhibit-detail/exhibit-detail.module.js
+++ b/frontend/exhibit-detail/exhibit-detail.module.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitDetail', [
   'ngRoute',
   'authentication',

--- a/frontend/exhibit-detail/exhibit-detail.template.html
+++ b/frontend/exhibit-detail/exhibit-detail.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <main role="main" class="no-section-nav">
 
   <section class="section" ng-if="!$ctrl.exhibitIdIsValid">

--- a/frontend/exhibit-display/exhibit-display.component.js
+++ b/frontend/exhibit-display/exhibit-display.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('exhibitDisplay')
   .component('exhibitDisplay', {

--- a/frontend/exhibit-display/exhibit-display.module.js
+++ b/frontend/exhibit-display/exhibit-display.module.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitDisplay', [
   'utilities',
 ]);

--- a/frontend/exhibit-display/exhibit-display.template.html
+++ b/frontend/exhibit-display/exhibit-display.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <style>
     #gridster {
         margin: 50px;

--- a/frontend/exhibit-edit/exhibit-edit.component.js
+++ b/frontend/exhibit-edit/exhibit-edit.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('exhibitEdit')
   .component('exhibitEdit', {

--- a/frontend/exhibit-edit/exhibit-edit.module.js
+++ b/frontend/exhibit-edit/exhibit-edit.module.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitEdit', [
   'authentication',
   'utilities',

--- a/frontend/exhibit-edit/exhibit-edit.template.html
+++ b/frontend/exhibit-edit/exhibit-edit.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <main role="main" class="no-section-nav">
 
 

--- a/frontend/exhibit-list/exhibit-list.component.js
+++ b/frontend/exhibit-list/exhibit-list.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('exhibitList')
   .component('exhibitList', {

--- a/frontend/exhibit-list/exhibit-list.module.js
+++ b/frontend/exhibit-list/exhibit-list.module.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('exhibitList', [
   'authentication',
   'utilities',

--- a/frontend/exhibit-list/exhibit-list.template.html
+++ b/frontend/exhibit-list/exhibit-list.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <main role="main" class="no-section-nav">
     <section class="section">
         <div class="row pad" id="search">

--- a/frontend/index-header/index-header.component.js
+++ b/frontend/index-header/index-header.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('indexHeader')
   .component('indexHeader', {

--- a/frontend/index-header/index-header.module.js
+++ b/frontend/index-header/index-header.module.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('indexHeader', [
   'loginButton',
 ]);

--- a/frontend/index-header/index-header.template.html
+++ b/frontend/index-header/index-header.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <header class="site-header" itemscope="itemscope" itemtype="http://schema.org/CollegeOrUniversity" role="banner" ng-if="!$ctrl.displayMode">
     <div class="row pad">
         <h4><a class="title" href="exhibits/" itemprop="department">Hello Collectome</a></h4>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <!DOCTYPE html>
 <html class="no-js ie9" itemscope="itemscope" itemtype="http://schema.org/Webpage" lang="en" ng-app="collectomeApp">
 

--- a/frontend/login-button/login-button.component.js
+++ b/frontend/login-button/login-button.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('loginButton')
   .component('loginButton', {

--- a/frontend/login-button/login-button.module.js
+++ b/frontend/login-button/login-button.module.js
@@ -1,1 +1,5 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('loginButton', ['authentication', 'utilities']);

--- a/frontend/login-button/login-button.template.html
+++ b/frontend/login-button/login-button.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <span ng-if="!$ctrl.authentication.isAuthorized">
     <button class="button right" ng-click="$ctrl.authenticateAsGitHubUser()">Log in via GitHub</button>
 </span>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1611,7 +1611,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1629,11 +1630,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1646,15 +1649,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1757,7 +1763,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1767,6 +1774,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1779,17 +1787,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -1806,6 +1817,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -1878,7 +1890,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -1888,6 +1901,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -1963,7 +1977,8 @@
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -1993,6 +2008,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2010,6 +2026,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2048,11 +2065,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -2705,6 +2724,15 @@
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
+      }
+    },
+    "license-check-and-add": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/license-check-and-add/-/license-check-and-add-2.3.6.tgz",
+      "integrity": "sha512-fTSOoJL12YhsTOS+xqutJ7uwIcN4kPcmhCk39FWTjc1Zllyc62JGT1i+NqTfyTh38wzLQDzfLDjqsI4jSzMnfg==",
+      "dev": true,
+      "requires": {
+        "pkg-conf": "^1.1.2"
       }
     },
     "limiter": {
@@ -3361,6 +3389,18 @@
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
       "requires": {
         "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-conf": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-1.1.3.tgz",
+      "integrity": "sha1-N45W1v0T6Iv7b0ol33qD+qvduls=",
+      "dev": true,
+      "requires": {
+        "find-up": "^1.0.0",
+        "load-json-file": "^1.1.0",
+        "object-assign": "^4.0.1",
+        "symbol": "^0.2.1"
       }
     },
     "pkg-dir": {
@@ -4202,6 +4242,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+    },
+    "symbol": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/symbol/-/symbol-0.2.3.tgz",
+      "integrity": "sha1-O5hzuKkB5Hxu/iFSajrDcu8ou8c=",
+      "dev": true
     },
     "symbol-observable": {
       "version": "1.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "eslint": "^5.12.0",
     "eslint-config-airbnb-base": "^13.1.0",
-    "eslint-plugin-import": "^2.14.0"
+    "eslint-plugin-import": "^2.14.0",
+    "license-check-and-add": "^2.3.6"
   },
   "eslintConfig": {
     "extends": "airbnb-base",
@@ -25,7 +26,39 @@
       "angular": false
     }
   },
+  "license-check-and-add-config": {
+    "folder": "..",
+    "license": "../LICENSE",
+    "exact_paths_method": "EXCLUDE",
+    "exact_paths": [
+      ".git",
+      "frontend/node_modules",
+      "README.md",
+      "LICENSE"
+    ],
+    "file_type_method": "EXCLUDE",
+    "file_types": [".md"],
+    "license_formats": {
+      "gitattributes|editorconfig": {
+        "eachLine": {
+          "prepend": "# "
+        }
+      },
+      "ini": {
+        "eachLine": {
+          "prepend": "; "
+        }
+      },
+      "sql|bk": {
+        "eachLine": {
+          "prepend": "-- "
+        }
+      }
+    },
+    "insert_license": true
+  },
   "scripts": {
+    "license": "license-check-and-add",
     "serve": "node dev-server.js"
   }
 }

--- a/frontend/sameorigin-check/sameorigin-check.component.js
+++ b/frontend/sameorigin-check/sameorigin-check.component.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular
   .module('sameoriginCheck')
   .component('sameoriginCheck', {

--- a/frontend/sameorigin-check/sameorigin-check.module.js
+++ b/frontend/sameorigin-check/sameorigin-check.module.js
@@ -1,1 +1,5 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('sameoriginCheck', ['utilities']);

--- a/frontend/sameorigin-check/sameorigin-check.template.html
+++ b/frontend/sameorigin-check/sameorigin-check.template.html
@@ -1,3 +1,7 @@
+<!--
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+-->
 <main role="main" class="no-section-nav">
     <section class="section">
         <div class="row pad" id="search">

--- a/frontend/utilities/utilities.module.js
+++ b/frontend/utilities/utilities.module.js
@@ -1,1 +1,5 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 angular.module('utilities', ['api']);

--- a/frontend/utilities/utilities.service.js
+++ b/frontend/utilities/utilities.service.js
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 /* eslint-disable func-names */
 angular
   .module('utilities')

--- a/php/app.ini
+++ b/php/app.ini
@@ -1,3 +1,5 @@
+; Copyright (C) 2019 The Trustees of Indiana University
+; SPDX-License-Identifier: BSD-3-Clause
 [application]
 app_name  = AVL Showcase Prototype 1
 app_email = support@crate.io

--- a/php/index.php
+++ b/php/index.php
@@ -1,3 +1,7 @@
+/*
+Copyright (C) 2019 The Trustees of Indiana University
+SPDX-License-Identifier: BSD-3-Clause
+*/
 <?php
 error_reporting(E_STRICT);
 

--- a/sql/schemas.sql
+++ b/sql/schemas.sql
@@ -1,3 +1,5 @@
+-- Copyright (C) 2019 The Trustees of Indiana University
+-- SPDX-License-Identifier: BSD-3-Clause
 -- posts table
 DROP TABLE IF EXISTS guestbook.posts;
 

--- a/sql/schemas.sql.bk
+++ b/sql/schemas.sql.bk
@@ -1,3 +1,5 @@
+-- Copyright (C) 2019 The Trustees of Indiana University
+-- SPDX-License-Identifier: BSD-3-Clause
 -- posts table
 DROP TABLE IF EXISTS guestbook.posts;
 


### PR DESCRIPTION
I recently learned of the recommendations from the [IU Open Source Administrators](https://indiana-university.github.io/). They include licensing with BSD-3 and inserting license and copyright info into all source files. This PR adds an npm script which automatically checks for the info and inserts it if it is missing. It can also be configured to search for and remove license info if we need to change things later.

We'll need to check with the Immersive Scholar folks to see if BSD-3 works for them.